### PR TITLE
Implement add-below handler and remove duplicate underline

### DIFF
--- a/src/BopppsPromptGenerator.js
+++ b/src/BopppsPromptGenerator.js
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -50,9 +49,8 @@ const EnhancedRichTextEditor = ({ content, onChange, placeholder, className = ""
       StarterKit.configure({
         // Disable extensions we're adding separately to avoid duplicates
         link: false,          // We're adding Link separately
-        // Note: StarterKit doesn't include Underline by default, so no need to disable it
       }),
-      Underline,
+      // Underline extension is included with StarterKit; avoid registering twice
       TextAlign.configure({
         types: ['heading', 'paragraph'],
       }),

--- a/src/ContentBlocks/BlockRenderer.js
+++ b/src/ContentBlocks/BlockRenderer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TextRenderer from './renderers/TextRenderer';
+import HeadlineRenderer from './renderers/HeadlineRenderer';
 import BoxRenderer from './renderers/BoxRenderer';
 import VideoRenderer from './renderers/VideoRenderer';
 import ImageRenderer from './renderers/ImageRenderer';
@@ -21,6 +22,9 @@ const BlockRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtml
         case 'heading':
         case 'list':
             return <TextRenderer {...commonProps} />;
+
+        case 'headline':
+            return <HeadlineRenderer {...commonProps} />;
 
         case 'info-box':
         case 'exercise-box':

--- a/src/ContentBlocks/BlockRenderer.js
+++ b/src/ContentBlocks/BlockRenderer.js
@@ -7,6 +7,7 @@ import ImageRenderer from './renderers/ImageRenderer';
 import GalleryRenderer from './renderers/GalleryRenderer';
 import AudioRenderer from './renderers/AudioRenderer';
 import CardRenderer from './renderers/CardRenderer';
+import HtmlRenderer from './renderers/HtmlRenderer';
 
 const BlockRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtmlMode }) => {
     const commonProps = {
@@ -25,6 +26,9 @@ const BlockRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtml
 
         case 'headline':
             return <HeadlineRenderer {...commonProps} />;
+
+        case 'html':
+            return <HtmlRenderer {...commonProps} />;
 
         case 'info-box':
         case 'exercise-box':

--- a/src/ContentBlocks/ContentBlock.js
+++ b/src/ContentBlocks/ContentBlock.js
@@ -14,6 +14,7 @@ import AddBelowDropdown from './Section';
 
 // Import your modular components
 import RichTextEditor from '../RichTextEditor';
+import HeadlineEditor from '../HeadlineEditor';
 
 // Import utility functions and components (adjust paths based on your structure)
 import {
@@ -125,7 +126,19 @@ const ContentBlock = ({
                         />
                     </div>
                 ) : (
-                    <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: block.content }} />
+                    <div className="rich-editor-content" dangerouslySetInnerHTML={{ __html: block.content }} />
+                );
+
+            case 'headline':
+                return isEditMode ? (
+                    <div onClick={(e) => e.stopPropagation()}>
+                        <HeadlineEditor
+                            content={block.content}
+                            onChange={(content) => onBlockUpdate({ ...block, content })}
+                        />
+                    </div>
+                ) : (
+                    <div className="headline-preview" dangerouslySetInnerHTML={{ __html: block.content }} />
                 );
 
             case 'info-box':
@@ -165,7 +178,7 @@ const ContentBlock = ({
                                         />
                                     </div>
                                 ) : (
-                                    <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: block.content }} />
+                                    <div className="rich-editor-content" dangerouslySetInnerHTML={{ __html: block.content }} />
                                 )}
                             </div>
                         </div>

--- a/src/ContentBlocks/ContentBlock.js
+++ b/src/ContentBlocks/ContentBlock.js
@@ -141,6 +141,22 @@ const ContentBlock = ({
                     <div className="headline-preview" dangerouslySetInnerHTML={{ __html: block.content }} />
                 );
 
+            case 'html':
+                return isEditMode ? (
+                    <div onClick={(e) => e.stopPropagation()}>
+                        <textarea
+                            value={block.content}
+                            onChange={(e) => onBlockUpdate({ ...block, content: e.target.value })}
+                            className="w-full min-h-[150px] p-3 border border-gray-300 rounded-lg font-mono text-sm"
+                        />
+                    </div>
+                ) : (
+                    <div
+                        className="html-block-preview rich-editor-content"
+                        dangerouslySetInnerHTML={{ __html: block.content }}
+                    />
+                );
+
             case 'info-box':
             case 'exercise-box':
             case 'warning-box':

--- a/src/ContentBlocks/ContentBlock.js
+++ b/src/ContentBlocks/ContentBlock.js
@@ -1,22 +1,16 @@
 // ContentBlock Component with Dropdown Menu - FIXED VERSION
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import {
     ChevronDown,
-    Plus,
-    Video,
-    Image,
-    Music,
-    CreditCard,
-    List,
     AlertCircle,
     CheckCircle,
     AlertTriangle,
-    FileText,
     Edit3,
     X,
     GripVertical,
     ChevronUp
 } from 'lucide-react';
+import AddBelowDropdown from './Section';
 
 // Import your modular components
 import RichTextEditor from '../RichTextEditor';
@@ -68,22 +62,8 @@ const ContentBlock = ({
     sectionId // NEW: Current section ID
 }) => {
     // Now your existing state variables should work:
-    const [isDragging, setIsDragging] = React.useState(false);
-    const [showDropdown, setShowDropdown] = React.useState(false);
-    const blockRef = React.useRef(null);
-    const dropdownRef = React.useRef(null);
-
-    // Close dropdown when clicking outside
-    React.useEffect(() => {
-        const handleClickOutside = (event) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-                setShowDropdown(false);
-            }
-        };
-
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
+    const [isDragging, setIsDragging] = useState(false);
+    const blockRef = useRef(null);
 
     // FIXED: Only handle drag events from the drag handle, not the entire block
     const handleDragStart = (e) => {
@@ -125,22 +105,9 @@ const ContentBlock = ({
             // Fallback - you can implement a default behavior here
             alert(`Add ${contentType} block functionality needs to be implemented in the parent component`);
         }
-        setShowDropdown(false);
+        // dropdown closes within AddBelowDropdown component
     };
 
-    // Content type options for dropdown
-    const contentOptions = [
-        { type: 'text', icon: FileText, label: 'Text Block', color: 'text-gray-600' },
-        { type: 'heading', icon: FileText, label: 'Heading', color: 'text-blue-600' },
-        { type: 'list', icon: List, label: 'List', color: 'text-green-600' },
-        { type: 'info-box', icon: AlertCircle, label: 'Info Box', color: 'text-blue-500' },
-        { type: 'exercise-box', icon: AlertCircle, label: 'Exercise Box', color: 'text-emerald-500' },
-        { type: 'warning-box', icon: AlertCircle, label: 'Warning Box', color: 'text-amber-500' },
-        { type: 'video', icon: Video, label: 'Video', color: 'text-red-500' },
-        { type: 'image', icon: Image, label: 'Image/Gallery', color: 'text-purple-500' },
-        { type: 'audio', icon: Music, label: 'Audio', color: 'text-indigo-500' },
-        { type: 'cards', icon: CreditCard, label: 'Cards', color: 'text-yellow-600' },
-    ];
 
     const renderContent = () => {
         switch (block.type) {
@@ -413,54 +380,8 @@ const ContentBlock = ({
 
             {/* NEW: Add Content Below Button & Dropdown */}
             {isEditMode && (
-                <div className="relative flex justify-center my-2">
-                    <div className="relative" ref={dropdownRef}>
-                        <button
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                setShowDropdown(!showDropdown);
-                            }}
-                            className="flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors shadow-md"
-                            title="Add content below this block"
-                        >
-                            <Plus size={16} />
-                            <span className="text-sm font-medium">Add Below</span>
-                            <ChevronDown size={14} className={`transition-transform ${showDropdown ? 'rotate-180' : ''}`} />
-                        </button>
-
-                        {/* Dropdown Menu */}
-                        {showDropdown && (
-                            <div className="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 w-56 bg-white rounded-lg shadow-xl border border-gray-200 z-50 py-2">
-                                <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-100">
-                                    Text Content
-                                </div>
-                                {contentOptions.slice(0, 6).map((option) => (
-                                    <button
-                                        key={option.type}
-                                        onClick={() => handleAddContent(option.type)}
-                                        className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                                    >
-                                        <option.icon size={16} className={option.color} />
-                                        <span>{option.label}</span>
-                                    </button>
-                                ))}
-
-                                <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-100 border-t border-gray-100 mt-1">
-                                    Media Content
-                                </div>
-                                {contentOptions.slice(6).map((option) => (
-                                    <button
-                                        key={option.type}
-                                        onClick={() => handleAddContent(option.type)}
-                                        className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                                    >
-                                        <option.icon size={16} className={option.color} />
-                                        <span>{option.label}</span>
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-                    </div>
+                <div className="my-2 flex justify-center">
+                    <AddBelowDropdown onAddContent={handleAddContent} />
                 </div>
             )}
         </div>

--- a/src/ContentBlocks/Section.js
+++ b/src/ContentBlocks/Section.js
@@ -48,8 +48,16 @@ const AddBelowDropdown = ({ onAddContent }) => {
             if (!buttonRef.current || !menuRef.current) return;
             const buttonRect = buttonRef.current.getBoundingClientRect();
             const menuHeight = menuRef.current.offsetHeight;
-            const spaceBelow = window.innerHeight - buttonRect.bottom;
+
+            // Determine available space within the closest accordion container
+            const container = buttonRef.current.closest('.accordion-content-wrapper');
+            const containerRect = container
+                ? container.getBoundingClientRect()
+                : { top: 0, bottom: window.innerHeight };
+
+            const spaceBelow = containerRect.bottom - buttonRect.bottom;
             const top = spaceBelow < menuHeight ? buttonRect.top - menuHeight : buttonRect.bottom;
+
             setPosition({
                 top: top + window.scrollY,
                 left: buttonRect.left + window.scrollX
@@ -126,7 +134,10 @@ const AddBelowDropdown = ({ onAddContent }) => {
     return (
         <div className="relative" ref={buttonRef}>
             <button
-                onClick={toggleDropdown}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    toggleDropdown();
+                }}
                 className="flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors shadow-md"
             >
                 <Plus size={16} />

--- a/src/ContentBlocks/Section.js
+++ b/src/ContentBlocks/Section.js
@@ -5,6 +5,7 @@ import {
     Plus,
     FileText,
     Heading,
+    Code,
     List,
     AlertCircle,
     Video,
@@ -24,6 +25,7 @@ const AddBelowDropdown = ({ onAddContent }) => {
     const options = [
         { type: 'text', icon: FileText, label: 'Text Block', color: 'text-gray-600' },
         { type: 'headline', icon: Heading, label: 'Headline', color: 'text-indigo-600' },
+        { type: 'html', icon: Code, label: 'HTML Block', color: 'text-pink-600' },
         { type: 'heading', icon: FileText, label: 'Heading', color: 'text-blue-600' },
         { type: 'list', icon: List, label: 'List', color: 'text-green-600' },
         { type: 'info-box', icon: AlertCircle, label: 'Info Box', color: 'text-blue-500' },
@@ -103,7 +105,7 @@ const AddBelowDropdown = ({ onAddContent }) => {
                   <li className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-100">
                       Text Content
                   </li>
-                  {options.slice(0, 6).map((option) => (
+                  {options.slice(0, 7).map((option) => (
                       <li key={option.type}>
                           <button
                               onClick={() => handleSelect(option.type)}
@@ -117,7 +119,7 @@ const AddBelowDropdown = ({ onAddContent }) => {
                   <li className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-t border-gray-100 border-b border-gray-100 mt-1">
                       Media Content
                   </li>
-                  {options.slice(6).map((option) => (
+                  {options.slice(7).map((option) => (
                       <li key={option.type}>
                           <button
                               onClick={() => handleSelect(option.type)}

--- a/src/ContentBlocks/Section.js
+++ b/src/ContentBlocks/Section.js
@@ -4,6 +4,7 @@ import {
     ChevronDown,
     Plus,
     FileText,
+    Heading,
     List,
     AlertCircle,
     Video,
@@ -22,6 +23,7 @@ const AddBelowDropdown = ({ onAddContent }) => {
 
     const options = [
         { type: 'text', icon: FileText, label: 'Text Block', color: 'text-gray-600' },
+        { type: 'headline', icon: Heading, label: 'Headline', color: 'text-indigo-600' },
         { type: 'heading', icon: FileText, label: 'Heading', color: 'text-blue-600' },
         { type: 'list', icon: List, label: 'List', color: 'text-green-600' },
         { type: 'info-box', icon: AlertCircle, label: 'Info Box', color: 'text-blue-500' },

--- a/src/ContentBlocks/Section.js
+++ b/src/ContentBlocks/Section.js
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import {
+    ChevronDown,
+    Plus,
+    FileText,
+    List,
+    AlertCircle,
+    Video,
+    Image,
+    Music,
+    CreditCard
+} from 'lucide-react';
+
+// Dropdown that allows adding blocks below the current section without being clipped by parent overflow
+const AddBelowDropdown = ({ onAddContent }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [position, setPosition] = useState({ top: 0, left: 0 });
+
+    const buttonRef = useRef(null);
+    const menuRef = useRef(null);
+
+    const options = [
+        { type: 'text', icon: FileText, label: 'Text Block', color: 'text-gray-600' },
+        { type: 'heading', icon: FileText, label: 'Heading', color: 'text-blue-600' },
+        { type: 'list', icon: List, label: 'List', color: 'text-green-600' },
+        { type: 'info-box', icon: AlertCircle, label: 'Info Box', color: 'text-blue-500' },
+        { type: 'exercise-box', icon: AlertCircle, label: 'Exercise Box', color: 'text-emerald-500' },
+        { type: 'warning-box', icon: AlertCircle, label: 'Warning Box', color: 'text-amber-500' },
+        { type: 'video', icon: Video, label: 'Video', color: 'text-red-500' },
+        { type: 'image', icon: Image, label: 'Image/Gallery', color: 'text-purple-500' },
+        { type: 'audio', icon: Music, label: 'Audio', color: 'text-indigo-500' },
+        { type: 'cards', icon: CreditCard, label: 'Cards', color: 'text-yellow-600' }
+    ];
+
+    const toggleDropdown = () => setIsOpen(!isOpen);
+
+    const handleSelect = (type) => {
+        onAddContent && onAddContent(type);
+        setIsOpen(false);
+    };
+
+    // Determine if there's enough space below; if not, position the menu above
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const updatePosition = () => {
+            if (!buttonRef.current || !menuRef.current) return;
+            const buttonRect = buttonRef.current.getBoundingClientRect();
+            const menuHeight = menuRef.current.offsetHeight;
+            const spaceBelow = window.innerHeight - buttonRect.bottom;
+            const top = spaceBelow < menuHeight ? buttonRect.top - menuHeight : buttonRect.bottom;
+            setPosition({
+                top: top + window.scrollY,
+                left: buttonRect.left + window.scrollX
+            });
+        };
+
+        updatePosition();
+        window.addEventListener('resize', updatePosition);
+        window.addEventListener('scroll', updatePosition, true);
+        return () => {
+            window.removeEventListener('resize', updatePosition);
+            window.removeEventListener('scroll', updatePosition, true);
+        };
+    }, [isOpen]);
+
+    // Close dropdown when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (
+                buttonRef.current &&
+                !buttonRef.current.contains(e.target) &&
+                menuRef.current &&
+                !menuRef.current.contains(e.target)
+            ) {
+                setIsOpen(false);
+            }
+        };
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen]);
+
+    const menu = isOpen
+        ? ReactDOM.createPortal(
+              <ul
+                  ref={menuRef}
+                  className="absolute z-50 w-56 bg-white border border-gray-200 rounded-lg shadow-xl py-2"
+                  style={{ top: position.top, left: position.left }}
+              >
+                  <li className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-100">
+                      Text Content
+                  </li>
+                  {options.slice(0, 6).map((option) => (
+                      <li key={option.type}>
+                          <button
+                              onClick={() => handleSelect(option.type)}
+                              className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                              <option.icon size={16} className={option.color} />
+                              <span>{option.label}</span>
+                          </button>
+                      </li>
+                  ))}
+                  <li className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-t border-gray-100 border-b border-gray-100 mt-1">
+                      Media Content
+                  </li>
+                  {options.slice(6).map((option) => (
+                      <li key={option.type}>
+                          <button
+                              onClick={() => handleSelect(option.type)}
+                              className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                              <option.icon size={16} className={option.color} />
+                              <span>{option.label}</span>
+                          </button>
+                      </li>
+                  ))}
+              </ul>,
+              document.body
+          )
+        : null;
+
+    return (
+        <div className="relative" ref={buttonRef}>
+            <button
+                onClick={toggleDropdown}
+                className="flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors shadow-md"
+            >
+                <Plus size={16} />
+                <span className="text-sm font-medium">Add Below</span>
+                <ChevronDown size={14} className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+            </button>
+            {menu}
+        </div>
+    );
+};
+
+export default AddBelowDropdown;

--- a/src/ContentBlocks/index.js
+++ b/src/ContentBlocks/index.js
@@ -1,6 +1,7 @@
 export { default as ContentBlock } from './ContentBlock';
 export { default as BlockRenderer } from './BlockRenderer';
 export { default as TextRenderer } from './renderers/TextRenderer';
+export { default as HeadlineRenderer } from './renderers/HeadlineRenderer';
 export { default as VideoRenderer } from './renderers/VideoRenderer';
 export { default as ImageRenderer } from './renderers/ImageRenderer';
 export { default as AudioRenderer } from './renderers/AudioRenderer';

--- a/src/ContentBlocks/index.js
+++ b/src/ContentBlocks/index.js
@@ -8,3 +8,4 @@ export { default as AudioRenderer } from './renderers/AudioRenderer';
 export { default as CardRenderer } from './renderers/CardRenderer';
 export { default as GalleryRenderer } from './renderers/GalleryRenderer';
 export { default as BoxRenderer } from './renderers/BoxRenderer';
+export { default as HtmlRenderer } from './renderers/HtmlRenderer';

--- a/src/ContentBlocks/renderers/BoxRenderer.js
+++ b/src/ContentBlocks/renderers/BoxRenderer.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { AlertCircle, CheckCircle, AlertTriangle } from 'lucide-react';
-import RichTextEditor from '../../RichTextEditor'; // Adjust path if needed
+import RichTextEditor from '../../RichTextEditor';
 
 const BoxRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtmlMode }) => {
     const boxConfig = {
@@ -39,7 +39,7 @@ const BoxRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtmlMo
                             isPreviewMode={false}
                         />
                     ) : (
-                        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: block.content }} />
+                        <div className="rich-editor-content" dangerouslySetInnerHTML={{ __html: block.content }} />
                     )}
                 </div>
             </div>

--- a/src/ContentBlocks/renderers/HeadlineRenderer.js
+++ b/src/ContentBlocks/renderers/HeadlineRenderer.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import HeadlineEditor from '../../HeadlineEditor';
+
+const HeadlineRenderer = ({ block, isEditMode, onBlockUpdate }) => {
+    return isEditMode ? (
+        <HeadlineEditor
+            content={block.content}
+            onChange={(content) => onBlockUpdate({ ...block, content })}
+        />
+    ) : (
+        <div className="headline-preview" dangerouslySetInnerHTML={{ __html: block.content }} />
+    );
+};
+
+export default HeadlineRenderer;

--- a/src/ContentBlocks/renderers/HtmlRenderer.js
+++ b/src/ContentBlocks/renderers/HtmlRenderer.js
@@ -1,12 +1,101 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { Indent, Outdent } from 'lucide-react';
 
 const HtmlRenderer = ({ block, isEditMode, onBlockUpdate }) => {
+  const textareaRef = useRef(null);
+
+  const autoResize = () => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    const maxHeight = 600;
+    ta.style.height = `${Math.min(ta.scrollHeight, maxHeight)}px`;
+  };
+
+  useEffect(() => {
+    if (isEditMode) autoResize();
+  }, [block.content, isEditMode]);
+
+  const handleChange = (e) => {
+    onBlockUpdate({ ...block, content: e.target.value });
+  };
+
+  const handleIndent = () => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const { selectionStart, selectionEnd } = ta;
+    const value = block.content;
+    const before = value.slice(0, selectionStart);
+    const selected = value.slice(selectionStart, selectionEnd);
+    const after = value.slice(selectionEnd);
+    const lines = selected.split('\n');
+    const indented = lines.map((line) => `  ${line}`).join('\n');
+    const newValue = before + indented + after;
+    onBlockUpdate({ ...block, content: newValue });
+    requestAnimationFrame(() => {
+      ta.selectionStart = selectionStart + 2;
+      ta.selectionEnd = selectionEnd + 2 * lines.length;
+    });
+  };
+
+  const handleOutdent = () => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const { selectionStart, selectionEnd } = ta;
+    const value = block.content;
+    const before = value.slice(0, selectionStart);
+    const selected = value.slice(selectionStart, selectionEnd);
+    const after = value.slice(selectionEnd);
+    let removed = 0;
+    const lines = selected.split('\n');
+    const outdented = lines
+      .map((line) => {
+        if (line.startsWith('  ')) {
+          removed += 2;
+          return line.slice(2);
+        }
+        if (line.startsWith('\t')) {
+          removed += 1;
+          return line.slice(1);
+        }
+        return line;
+      })
+      .join('\n');
+    const newValue = before + outdented + after;
+    onBlockUpdate({ ...block, content: newValue });
+    requestAnimationFrame(() => {
+      ta.selectionStart = Math.max(selectionStart - 2, 0);
+      ta.selectionEnd = Math.max(selectionEnd - removed, 0);
+    });
+  };
+
   return isEditMode ? (
-    <textarea
-      value={block.content}
-      onChange={(e) => onBlockUpdate({ ...block, content: e.target.value })}
-      className="w-full min-h-[150px] p-3 border border-gray-300 rounded-lg font-mono text-sm"
-    />
+    <div className="space-y-2">
+      <div className="flex gap-2 text-gray-600">
+        <button
+          type="button"
+          onClick={handleIndent}
+          className="p-1 hover:text-black"
+          title="Indent"
+        >
+          <Indent className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={handleOutdent}
+          className="p-1 hover:text-black"
+          title="Outdent"
+        >
+          <Outdent className="w-4 h-4" />
+        </button>
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={block.content}
+        onChange={handleChange}
+        className="w-full min-h-[150px] max-h-[600px] overflow-auto resize-y p-3 border border-gray-300 rounded-lg font-mono text-sm"
+      />
+    </div>
   ) : (
     <div
       className="html-block-preview rich-editor-content"

--- a/src/ContentBlocks/renderers/HtmlRenderer.js
+++ b/src/ContentBlocks/renderers/HtmlRenderer.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const HtmlRenderer = ({ block, isEditMode, onBlockUpdate }) => {
+  return isEditMode ? (
+    <textarea
+      value={block.content}
+      onChange={(e) => onBlockUpdate({ ...block, content: e.target.value })}
+      className="w-full min-h-[150px] p-3 border border-gray-300 rounded-lg font-mono text-sm"
+    />
+  ) : (
+    <div
+      className="html-block-preview rich-editor-content"
+      dangerouslySetInnerHTML={{ __html: block.content }}
+    />
+  );
+};
+
+export default HtmlRenderer;

--- a/src/ContentBlocks/renderers/TextRenderer.js
+++ b/src/ContentBlocks/renderers/TextRenderer.js
@@ -3,7 +3,7 @@
 // COPY AND PASTE this EXACT code:
 
 import React from 'react';
-import RichTextEditor from '../../RichTextEditor'; // Adjust path if needed
+import RichTextEditor from '../../RichTextEditor';
 
 const TextRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtmlMode }) => {
     return isEditMode ? (
@@ -15,7 +15,7 @@ const TextRenderer = ({ block, isEditMode, onBlockUpdate, htmlModes, toggleHtmlM
             isPreviewMode={false}
         />
     ) : (
-        <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: block.content }} />
+        <div className="rich-editor-content" dangerouslySetInnerHTML={{ __html: block.content }} />
     );
 };
 

--- a/src/HeadlineEditor.js
+++ b/src/HeadlineEditor.js
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import Document from '@tiptap/extension-document';
+import Text from '@tiptap/extension-text';
+import Heading from '@tiptap/extension-heading';
+import Placeholder from '@tiptap/extension-placeholder';
+
+const HeadlineEditor = ({ content, onChange }) => {
+  const editor = useEditor({
+    extensions: [
+      Document.extend({ content: 'heading' }),
+      Text,
+      Heading.configure({ levels: [1, 2] }),
+      Placeholder.configure({ placeholder: 'Add headline...' }),
+    ],
+    content: content || '<h1></h1>',
+    onUpdate: ({ editor }) => {
+      onChange && onChange(editor.getHTML());
+    },
+  });
+
+  useEffect(() => {
+    if (editor && content !== editor.getHTML()) {
+      editor.commands.setContent(content || '<h1></h1>', false);
+    }
+  }, [editor, content]);
+
+  return <EditorContent editor={editor} className="rich-editor-content" />;
+};
+
+export default HeadlineEditor;

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -3263,6 +3263,27 @@ const LectureTemplateSystem = ({ initialData }) => {
                 </React.Fragment>
               )}
             </button>
+            <button
+              onClick={handleSave}
+              className="px-3 py-1 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors flex items-center gap-2"
+            >
+              <Download size={16} />
+              Export
+            </button>
+            <input
+              type="file"
+              accept=".json"
+              onChange={handleLoad}
+              className="hidden"
+              id="toolbarLoadFile"
+            />
+            <button
+              onClick={() => document.getElementById('toolbarLoadFile').click()}
+              className="px-3 py-1 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors flex items-center gap-2"
+            >
+              <Upload size={16} />
+              Load
+            </button>
             <div className="ml-auto text-sm text-gray-500">
               {openSectionIds.length}/{sections.length} open
             </div>

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -61,7 +61,8 @@ import {
   blockToHtml,
   getVideoEmbedHtml,
   generateCompleteHtml,
-  embedImagesInSections
+  embedImagesInSections,
+  fetchImageAsDataUrl
 } from './Utils/exportUtils';
 
 // Phase 1 Utility Imports - Validation Utils
@@ -1623,7 +1624,7 @@ const LectureTemplateSystem = ({ initialData }) => {
   const [showLogoSettings, setShowLogoSettings] = useState(false);
 
   // NEW: Use the logo context
-  const { getLogoHtml, hasLogo } = useLogo();
+  const { logo, getLogoHtml, hasLogo } = useLogo();
 
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [tempTitle, setTempTitle] = useState('');
@@ -2035,10 +2036,19 @@ const LectureTemplateSystem = ({ initialData }) => {
     showSaveIndicator('➕ New section added');
   };
 
+  const buildLogoHtml = async () => {
+    if (!logo) return '';
+    let src = logo;
+    if (!src.startsWith('data:')) {
+      src = await fetchImageAsDataUrl(src);
+    }
+    return `<img src="${src}" alt="School Logo" class="logo" style="max-height: 80px; margin-bottom: 10px;" />`;
+  };
+
   const handleExportPDF = async () => {
     showSaveIndicator('📄 Preparing PDF...', 'saving');
 
-    const logoHtml = getLogoHtml('logo');
+    const logoHtml = await buildLogoHtml();
 
     // Create clean header for PDF
     const headerHtml = `
@@ -2558,7 +2568,7 @@ const LectureTemplateSystem = ({ initialData }) => {
 
   const handleExportHTML = async () => {
     showSaveIndicator('🔒 Preparing locked HTML...', 'saving');
-    const logoHtml = getLogoHtml('logo');
+    const logoHtml = await buildLogoHtml();
 
     const processedSections = await embedImagesInSections(sections);
 

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -1947,11 +1947,14 @@ const LectureTemplateSystem = ({ initialData }) => {
   };
 
   const handleAddContent = (sectionId, contentType = 'text') => {
-    if (contentType === 'text') {
+    if (contentType === 'text' || contentType === 'headline') {
       const newBlock = {
         id: generateId(),
-        type: 'text',
-        content: 'Click to edit this text content.'
+        type: contentType,
+        content:
+          contentType === 'headline'
+            ? '<h1>Headline</h1>'
+            : 'Click to edit this text content.'
       };
 
       setSections(prevSections =>
@@ -1971,11 +1974,14 @@ const LectureTemplateSystem = ({ initialData }) => {
 
   // Add a new block directly below the specified block within a section
   const handleAddBlockBelow = (blockId, contentType = 'text', sectionId) => {
-    if (contentType === 'text') {
+    if (contentType === 'text' || contentType === 'headline') {
       const newBlock = {
         id: generateId(),
-        type: 'text',
-        content: 'Click to edit this text content.'
+        type: contentType,
+        content:
+          contentType === 'headline'
+            ? '<h1>Headline</h1>'
+            : 'Click to edit this text content.'
       };
 
       setSections(prevSections =>
@@ -2449,7 +2455,9 @@ const LectureTemplateSystem = ({ initialData }) => {
       case 'text':
       case 'heading':
       case 'list':
-        return `<div class="prose max-w-none">${block.content}</div>`;
+        return `<div class="rich-editor-content">${block.content}</div>`;
+      case 'headline':
+        return `<div class="headline-preview">${block.content}</div>`;
       case 'info-box':
       case 'exercise-box':
       case 'warning-box':
@@ -2458,7 +2466,7 @@ const LectureTemplateSystem = ({ initialData }) => {
           'exercise-box': { bg: 'bg-emerald-50', border: 'border-l-4 border-emerald-400' },
           'warning-box': { bg: 'bg-amber-50', border: 'border-l-4 border-amber-400' }
         }[block.type];
-        return `<div class="p-4 rounded-lg ${boxConfig.bg} ${boxConfig.border}"><div class="prose max-w-none">${block.content}</div></div>`;
+        return `<div class="p-4 rounded-lg ${boxConfig.bg} ${boxConfig.border}"><div class="rich-editor-content">${block.content}</div></div>`;
       case 'video':
         const aspectClass = { '16-9': 'pb-[56.25%]', '4-3': 'pb-[75%]', '1-1': 'pb-[100%]', '21-9': 'pb-[42.85%]' }[block.aspectRatio] || 'pb-[56.25%]';
         const videoCitation = generateAPACitation(block.videoTitle, block.videoAuthor, block.videoDate, block.videoSource, block.videoUrl);

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -3088,10 +3088,11 @@ const LectureTemplateSystem = ({ initialData }) => {
       {/* Control Panel Toggle Button */}
       <button
         onClick={() => setIsControlPanelOpen(!isControlPanelOpen)}
-        className={`fixed top-6 z-50 w-12 h-12 bg-slate-700 hover:bg-slate-800 text-white rounded-xl flex items-center justify-center shadow-lg transition-all no-print ${isControlPanelOpen ? 'right-[26rem]' : 'right-6'
+        className={`fixed top-6 z-50 bg-slate-700 hover:bg-slate-800 text-white rounded-xl flex items-center gap-2 shadow-lg transition-all no-print h-12 px-4 ${isControlPanelOpen ? 'right-[26rem]' : 'right-6'
           }`}
       >
         <Settings size={20} />
+        <span>Customize Template</span>
       </button>
 
       <ControlPanel
@@ -3193,27 +3194,7 @@ const LectureTemplateSystem = ({ initialData }) => {
       {/* Navigation */}
       <nav className="bg-white border-b border-gray-200 sticky top-0 z-40 no-print">
         <div className="max-w-7xl mx-auto px-6">
-          <div className="flex items-center justify-between py-2">
-            {/* Left side - Collapse/Expand All Button */}
-            <button
-              onClick={handleToggleAllSections}
-              className="px-3 py-1 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors flex items-center gap-2"
-              title={openSectionIds.length > 0 ? "Collapse All Sections" : "Expand All Sections"}
-            >
-              {openSectionIds.length > 0 ? (
-                <React.Fragment>
-                  <ChevronUp size={16} />
-                  Collapse All
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  <ChevronDown size={16} />
-                  Expand All
-                </React.Fragment>
-              )}
-            </button>
-
-            {/* Center - Navigation Links */}
+          <div className="py-2 flex justify-center">
             <ul className="flex justify-center gap-1 flex-wrap">
               {sections.map(section => (
                 <li key={section.id}>
@@ -3231,14 +3212,55 @@ const LectureTemplateSystem = ({ initialData }) => {
                 </li>
               ))}
             </ul>
+          </div>
+        </div>
+      </nav>
 
-            {/* Right side - Section Count */}
-            <div className="text-sm text-gray-500">
+      {/* Control Bar */}
+      <div className="bg-gray-50 border-b border-gray-200 no-print">
+        <div className="max-w-7xl mx-auto px-6 py-2">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => { if (!isEditMode) handleToggleEditMode(); }}
+              className={`px-3 py-1 text-sm font-medium rounded-lg transition-colors ${isEditMode
+                ? 'bg-slate-700 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+            >
+              Edit Mode
+            </button>
+            <button
+              onClick={() => { if (isEditMode) handleToggleEditMode(); }}
+              className={`px-3 py-1 text-sm font-medium rounded-lg transition-colors ${!isEditMode
+                ? 'bg-slate-700 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+            >
+              Preview Mode
+            </button>
+            <button
+              onClick={handleToggleAllSections}
+              className="px-3 py-1 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors flex items-center gap-2"
+              title={openSectionIds.length > 0 ? "Collapse All Sections" : "Expand All Sections"}
+            >
+              {openSectionIds.length > 0 ? (
+                <React.Fragment>
+                  <ChevronUp size={16} />
+                  Collapse All
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  <ChevronDown size={16} />
+                  Expand All
+                </React.Fragment>
+              )}
+            </button>
+            <div className="ml-auto text-sm text-gray-500">
               {openSectionIds.length}/{sections.length} open
             </div>
           </div>
         </div>
-      </nav>
+      </div>
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-16 py-12">

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -1949,13 +1949,15 @@ const LectureTemplateSystem = ({ initialData }) => {
   };
 
   const handleAddContent = (sectionId, contentType = 'text') => {
-    if (contentType === 'text' || contentType === 'headline') {
+    if (contentType === 'text' || contentType === 'headline' || contentType === 'html') {
       const newBlock = {
         id: generateId(),
         type: contentType,
         content:
           contentType === 'headline'
             ? '<h1>Headline</h1>'
+            : contentType === 'html'
+            ? '<div>Custom HTML</div>'
             : 'Click to edit this text content.'
       };
 
@@ -1966,7 +1968,7 @@ const LectureTemplateSystem = ({ initialData }) => {
             : section
         )
       );
-      showSaveIndicator('➕ Text content added');
+      showSaveIndicator(contentType === 'html' ? '➕ HTML content added' : '➕ Text content added');
     } else {
       setModalContentType(contentType);
       setModalInitialData({ sectionId });
@@ -1976,13 +1978,15 @@ const LectureTemplateSystem = ({ initialData }) => {
 
   // Add a new block directly below the specified block within a section
   const handleAddBlockBelow = (blockId, contentType = 'text', sectionId) => {
-    if (contentType === 'text' || contentType === 'headline') {
+    if (contentType === 'text' || contentType === 'headline' || contentType === 'html') {
       const newBlock = {
         id: generateId(),
         type: contentType,
         content:
           contentType === 'headline'
             ? '<h1>Headline</h1>'
+            : contentType === 'html'
+            ? '<div>Custom HTML</div>'
             : 'Click to edit this text content.'
       };
 
@@ -1999,7 +2003,7 @@ const LectureTemplateSystem = ({ initialData }) => {
           return { ...section, blocks };
         })
       );
-      showSaveIndicator('➕ Text content added');
+      showSaveIndicator(contentType === 'html' ? '➕ HTML content added' : '➕ Text content added');
     } else {
       setModalContentType(contentType);
       setModalInitialData({ sectionId, insertAfterBlockId: blockId });
@@ -2470,6 +2474,8 @@ const LectureTemplateSystem = ({ initialData }) => {
         return `<div class="rich-editor-content">${block.content}</div>`;
       case 'headline':
         return `<div class="headline-preview">${block.content}</div>`;
+      case 'html':
+        return `<div class="html-block-preview rich-editor-content">${block.content}</div>`;
       case 'info-box':
       case 'exercise-box':
       case 'warning-box':

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -323,7 +323,7 @@ const Section = ({ section, onUpdate, isEditMode, onAddContent, onDeleteSection,
         className={`${colorConfig.bg} ${colorConfig.hover} text-white px-8 py-6 cursor-pointer flex justify-between items-center relative overflow-hidden transition-colors no-print`}
         onClick={onToggle}
       >
-        <h2 className="text-xl font-semibold">
+        <h2 className="text-xl font-semibold text-white">
           {headerLabel}
         </h2>
 

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -60,7 +60,8 @@ import {
 import {
   blockToHtml,
   getVideoEmbedHtml,
-  generateCompleteHtml
+  generateCompleteHtml,
+  embedImagesInSections
 } from './Utils/exportUtils';
 
 // Phase 1 Utility Imports - Validation Utils
@@ -2034,7 +2035,7 @@ const LectureTemplateSystem = ({ initialData }) => {
     showSaveIndicator('➕ New section added');
   };
 
-  const handleExportPDF = () => {
+  const handleExportPDF = async () => {
     showSaveIndicator('📄 Preparing PDF...', 'saving');
 
     const logoHtml = getLogoHtml('logo');
@@ -2066,7 +2067,8 @@ const LectureTemplateSystem = ({ initialData }) => {
     `;
 
     // Generate clean sections HTML with minimal spacing
-    const sectionsHtml = sections.map((section, index) => {
+    const processedSections = await embedImagesInSections(sections);
+    const sectionsHtml = processedSections.map((section, index) => {
       const label = studentFriendlyTitles[section.id] || section.title;
       const blocksHtml = section.blocks.map(getBlockHtml).join('');
 
@@ -2554,9 +2556,11 @@ const LectureTemplateSystem = ({ initialData }) => {
     }
   };
 
-  const handleExportHTML = () => {
+  const handleExportHTML = async () => {
     showSaveIndicator('🔒 Preparing locked HTML...', 'saving');
     const logoHtml = getLogoHtml('logo');
+
+    const processedSections = await embedImagesInSections(sections);
 
     // inside handleExportHTML (App.js)
     const headerHtml = `
@@ -2618,7 +2622,7 @@ const LectureTemplateSystem = ({ initialData }) => {
     };
 
     // inside handleExportHTML (App.js)
-    const sectionsHtml = sections.map(section => {
+    const sectionsHtml = processedSections.map(section => {
       const label = studentFriendlyTitles[section.id] || section.title;
       const colorConfig = sectionColors[section.id] || { bg: 'bg-slate-600' };
       const blocksHtml = section.blocks.map(getBlockHtml).join('');

--- a/src/Utils/exportUtils.js
+++ b/src/Utils/exportUtils.js
@@ -10,7 +10,9 @@ export const blockToHtml = (block) => {
         case 'text':
         case 'heading':
         case 'list':
-            return `<div class="my-4 prose max-w-none">${block.content}</div>`;
+            return `<div class="my-4 rich-editor-content">${block.content}</div>`;
+        case 'headline':
+            return `<div class="headline-preview">${block.content}</div>`;
 
         case 'info-box':
         case 'exercise-box':
@@ -23,7 +25,7 @@ export const blockToHtml = (block) => {
 
             return `
         <div class="my-6 p-4 rounded-lg ${boxConfig.bg} ${boxConfig.border}">
-          <div class="prose max-w-none">${block.content}</div>
+          <div class="rich-editor-content">${block.content}</div>
         </div>
       `;
 

--- a/src/Utils/exportUtils.js
+++ b/src/Utils/exportUtils.js
@@ -5,7 +5,7 @@ import { generateImageCitation, generateVideoCitation, generateAudioCitation } f
 import { CARD_STYLES, IMAGE_SIZES, GALLERY_COLUMNS } from './constants';
 
 // Helper to embed external images as data URIs for portable exports
-const fetchImageAsDataUrl = async (src) => {
+export const fetchImageAsDataUrl = async (src) => {
     try {
         const response = await fetch(src);
         const blob = await response.blob();
@@ -187,6 +187,15 @@ export const getVideoEmbedHtml = (src, platform) => {
 
 // Generate complete HTML export
 export const generateCompleteHtml = async (sections, headerData, displayDate, logoHtml) => {
+    let embeddedLogoHtml = logoHtml;
+    if (logoHtml) {
+        const match = logoHtml.match(/src="([^"]+)"/);
+        if (match && !match[1].startsWith('data:')) {
+            const dataUrl = await fetchImageAsDataUrl(match[1]);
+            embeddedLogoHtml = logoHtml.replace(match[1], dataUrl);
+        }
+    }
+
     const processedSections = await embedImagesInSections(sections);
     const headerHtml = `
     <header class="bg-white border-b border-gray-200">
@@ -194,7 +203,7 @@ export const generateCompleteHtml = async (sections, headerData, displayDate, lo
         <div class="flex items-start justify-between space-x-6">
           <div class="flex flex-col items-center md:items-start space-y-3">
             <p class="text-lg text-gray-600">${displayDate}</p>
-            ${logoHtml ? `<div class="flex items-center space-x-3">${logoHtml}<div><h1 class="text-3xl font-bold text-gray-900">${headerData.courseTopic}</h1></div></div>` : `<h1 class="text-3xl font-bold text-gray-900">${headerData.courseTopic}</h1>`}
+            ${embeddedLogoHtml ? `<div class="flex items-center space-x-3">${embeddedLogoHtml}<div><h1 class="text-3xl font-bold text-gray-900">${headerData.courseTopic}</h1></div></div>` : `<h1 class="text-3xl font-bold text-gray-900">${headerData.courseTopic}</h1>`}
             <p class="text-sm text-gray-500">Instructor: ${headerData.instructorName} | ${headerData.instructorEmail}</p>
           </div>
         </div>

--- a/src/Utils/exportUtils.js
+++ b/src/Utils/exportUtils.js
@@ -89,6 +89,9 @@ export const blockToHtml = (block) => {
         case 'headline':
             return `<div class="headline-preview">${block.content}</div>`;
 
+        case 'html':
+            return `<div class="html-block-preview rich-editor-content">${block.content}</div>`;
+
         case 'info-box':
         case 'exercise-box':
         case 'warning-box':

--- a/src/index.css
+++ b/src/index.css
@@ -137,6 +137,14 @@ body {
   border-color: #3b82f6 !important;
   background-color: rgba(59, 130, 246, 0.1) !important;
 }
+
+.rich-editor-content {
+  @apply max-w-none;
+}
+
+.headline-preview {
+  @apply text-[2.5rem] font-bold text-primary-700;
+}
 /* Enhanced Rich Text Editor Styles - Add these to your existing index.css */
 
 /* Enhanced Typography and Spacing */

--- a/src/index.css
+++ b/src/index.css
@@ -145,6 +145,10 @@ body {
 .headline-preview {
   @apply text-[2.5rem] font-bold text-primary-700;
 }
+
+.html-block-preview {
+  @apply my-4 p-4 border border-gray-200 rounded-lg;
+}
 /* Enhanced Rich Text Editor Styles - Add these to your existing index.css */
 
 /* Enhanced Typography and Spacing */


### PR DESCRIPTION
## Summary
- wire up `onAddBlockBelow` so adding a text block below an existing block inserts it directly in that section
- adjust modal save logic to support inserting new blocks at a specific position
- drop redundant `Underline` extension registration from the BOPPPS prompt editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689132d7ee3483308e25224e8d0cf986