### PR TITLE
Add mobile-optimized locked HTML export and enhance HTML block editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@codemirror/lang-html": "^6.4.9",
         "@tiptap/core": "^3.0.7",
         "@tiptap/extension-bubble-menu": "^3.0.9",
         "@tiptap/extension-code-block-lowlight": "^3.0.9",
@@ -32,6 +33,7 @@
         "@tiptap/pm": "^3.0.7",
         "@tiptap/react": "^3.0.7",
         "@tiptap/starter-kit": "^3.0.7",
+        "@uiw/react-codemirror": "^4.25.1",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.263.1",
         "react": "^18.3.1",
@@ -2124,6 +2126,144 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
+      "integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -3790,6 +3930,69 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
+      "integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -5769,6 +5972,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.1.tgz",
+      "integrity": "sha512-zxgA2QkvP3ZDKxTBc9UltNFTrSeFezGXcZtZj6qcsBxiMzowoEMP5mVwXcKjpzldpZVRuY+JCC+RsekEgid4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.1.tgz",
+      "integrity": "sha512-eESBKHndoYkaEGlKCwRO4KrnTw1HkWBxVpEeqntoWTpoFEUYxdLWUYmkPBVk4/u8YzVy9g91nFfIRpqe5LjApg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.1",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -7418,6 +7674,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -19549,6 +19820,12 @@
       "peerDependencies": {
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@codemirror/lang-html": "^6.4.9",
     "@tiptap/core": "^3.0.7",
     "@tiptap/extension-bubble-menu": "^3.0.9",
     "@tiptap/extension-code-block-lowlight": "^3.0.9",
@@ -26,6 +27,7 @@
     "@tiptap/pm": "^3.0.7",
     "@tiptap/react": "^3.0.7",
     "@tiptap/starter-kit": "^3.0.7",
+    "@uiw/react-codemirror": "^4.25.1",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.263.1",
     "react": "^18.3.1",

--- a/src/LessonTemplate.js
+++ b/src/LessonTemplate.js
@@ -26,6 +26,9 @@ import { TableRow } from '@tiptap/extension-table-row';
 import { TableHeader } from '@tiptap/extension-table-header';
 import { TableCell } from '@tiptap/extension-table-cell';
 import CodeBlock from '@tiptap/extension-code-block';
+import CodeMirror from '@uiw/react-codemirror';
+import { html as htmlLang } from '@codemirror/lang-html';
+import { lineNumbers } from '@codemirror/view';
 // Utility functions
 const generateId = () => 'id_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
 
@@ -246,7 +249,7 @@ const AutoSaveRecoveryModal = ({ isOpen, onRecover, onDiscard, timestamp }) => {
 const RichTextEditor = ({ content, onChange, isHtmlMode, onToggleHtmlMode, isPreviewMode = false }) => {
   const [htmlContent, setHtmlContent] = useState(content || '');
   const [htmlError, setHtmlError] = useState('');
-  const textareaRef = useRef(null);
+  const codeMirrorRef = useRef(null);
 
   const editor = useEditor({
     extensions: [
@@ -321,8 +324,7 @@ const RichTextEditor = ({ content, onChange, isHtmlMode, onToggleHtmlMode, isPre
     onToggleHtmlMode && onToggleHtmlMode();
   };
 
-  const handleHtmlChange = (e) => {
-    const value = e.target.value;
+  const handleHtmlChange = (value) => {
     setHtmlContent(value);
     setHtmlError('');
 
@@ -375,33 +377,20 @@ const RichTextEditor = ({ content, onChange, isHtmlMode, onToggleHtmlMode, isPre
     };
 
     const templateHtml = templates[template] || '';
-    const textarea = textareaRef.current;
-    if (textarea) {
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const newContent = htmlContent.substring(0, start) + templateHtml + htmlContent.substring(end);
+    const view = codeMirrorRef.current?.view;
+    if (view) {
+      const { from, to } = view.state.selection.main;
+      const tr = view.state.update({
+        changes: { from, to, insert: templateHtml },
+        selection: { anchor: from + templateHtml.length },
+      });
+      view.dispatch(tr);
+      const newContent = view.state.doc.toString();
       setHtmlContent(newContent);
       onChange && onChange(newContent);
-
-      setTimeout(() => {
-        textarea.focus();
-        textarea.setSelectionRange(start + templateHtml.length, start + templateHtml.length);
-      }, 0);
+      view.focus();
     }
   };
-
-  const autoResizeTextarea = () => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px';
-    }
-  };
-
-  useEffect(() => {
-    if (isHtmlMode && textareaRef.current) {
-      autoResizeTextarea();
-    }
-  }, [isHtmlMode, htmlContent]);
 
   const setLink = () => {
     const previousUrl = editor.getAttributes('link').href;
@@ -487,16 +476,14 @@ const RichTextEditor = ({ content, onChange, isHtmlMode, onToggleHtmlMode, isPre
             </div>
           )}
 
-          {/* HTML Textarea */}
+          {/* HTML Editor */}
           <div className="flex-1">
-            <textarea
-              ref={textareaRef}
+            <CodeMirror
+              ref={codeMirrorRef}
               value={htmlContent}
-              onChange={handleHtmlChange}
-              className="w-full min-h-96 p-4 font-mono text-sm border-none outline-none resize-none bg-gray-50"
-              style={{ fontFamily: 'Monaco, Consolas, "Courier New", monospace' }}
-              placeholder="Enter your HTML code here..."
-              onInput={autoResizeTextarea}
+              height="384px"
+              extensions={[htmlLang(), lineNumbers()]}
+              onChange={(value) => handleHtmlChange(value)}
             />
           </div>
 
@@ -1116,6 +1103,7 @@ const ControlPanel = ({
   onToggleEditMode,
   onExportPDF,
   onExportHTML,
+  onExportMobileHTML,
   onSave,
   onLoad,
   onAddSection,
@@ -1273,6 +1261,11 @@ const ControlPanel = ({
           <button onClick={onExportHTML} className="w-full p-3 bg-purple-500 hover:bg-purple-600 text-white rounded-xl font-medium flex items-center justify-center gap-2 transition-colors shadow-sm">
             <Download size={16} />
             Export Locked HTML
+          </button>
+
+          <button onClick={onExportMobileHTML} className="w-full p-3 bg-teal-500 hover:bg-teal-600 text-white rounded-xl font-medium flex items-center justify-center gap-2 transition-colors shadow-sm">
+            <Download size={16} />
+            Export Mobile HTML
           </button>
 
           <button onClick={onSave} className="w-full p-3 bg-blue-500 hover:bg-blue-600 text-white rounded-xl font-medium flex items-center justify-center gap-2 transition-colors shadow-sm">
@@ -3486,6 +3479,229 @@ const LectureTemplateSystem = ({ initialData }) => {
     showSaveIndicator('🔒 Locked HTML exported');
   };
 
+  const handleExportMobileHTML = () => {
+    showSaveIndicator('🔒 Preparing mobile HTML...', 'saving');
+    const logoHtml = getLogoHtml('logo');
+
+    const headerHtml = `
+  <header class="bg-white border-b border-gray-200">
+    <div class="max-w-md mx-auto px-4 py-6">
+      <div class="flex flex-col items-center space-y-4 text-center">
+        <p class="text-base text-gray-600">${displayDate}</p>
+        ${logoHtml ? `<div class="logo">${logoHtml}</div>` : ''}
+        <h1 class="text-2xl font-bold text-gray-900">
+          ${headerData.courseTopic.replace(/Week \\d+/, `Week ${week}`)}
+        </h1>
+        <div class="text-sm text-gray-600 space-y-1">
+          <div><span class="font-medium">Instructor:</span> ${headerData.instructorName}</div>
+          <div><span class="font-medium">Email:</span> ${headerData.instructorEmail}</div>
+        </div>
+      </div>
+    </div>
+  </header>
+`;
+
+    const navHtml = `
+<nav class="bg-white border-b border-gray-200 sticky top-0 z-40">
+  <div class="max-w-md mx-auto px-4 overflow-x-auto">
+    <ul class="flex gap-1 py-2 whitespace-nowrap">
+      ${sections.map(section => {
+        const label = studentFriendlyTitles[section.id] || section.title;
+        return `
+        <li>
+          <a
+            href="#${section.id}"
+            class="px-3 py-2 rounded-lg transition-all font-medium text-xs text-gray-700 hover:text-gray-900 hover:bg-gray-100"
+          >
+            ${label}
+          </a>
+        </li>`;
+      }).join('')}
+    </ul>
+  </div>
+</nav>
+`;
+
+    const sectionColors = {
+      'overview': { bg: 'bg-slate-600' }, 'bridge-in': { bg: 'bg-red-500' },
+      'outcomes': { bg: 'bg-emerald-500' }, 'pre-assessment': { bg: 'bg-amber-500' },
+      'participatory-learning': { bg: 'bg-blue-500' }, 'post-assessment': { bg: 'bg-purple-500' },
+      'summary': { bg: 'bg-indigo-500' }, 'resources': { bg: 'bg-gray-600' }
+    };
+
+    const sectionsHtml = sections.map(section => {
+      const label = studentFriendlyTitles[section.id] || section.title;
+      const colorConfig = sectionColors[section.id] || { bg: 'bg-slate-600' };
+      const blocksHtml = section.blocks.map(getBlockHtml).join('');
+
+      return `
+  <div id="${section.id}" class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6 overflow-hidden">
+    <div class="${colorConfig.bg} text-white px-4 py-3 cursor-pointer flex justify-between items-center section-header">
+      <h2 class="text-lg font-semibold">${label}</h2>
+      <div class="toggle-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
+             viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </div>
+    </div>
+    <div class="content-container closed">
+      <div>
+        <div class="p-4 text-sm">
+          ${blocksHtml}
+        </div>
+      </div>
+    </div>
+  </div>`;
+    }).join('');
+
+    const footerHtml = `
+      <footer class="bg-gray-900 text-white py-6 mt-12">
+        <div class="max-w-md mx-auto px-4 text-center text-sm">
+          <p class="mb-1 font-medium">${headerData.footerCourseInfo}</p>
+          <p class="mb-1 text-gray-300">${headerData.footerInstitution}</p>
+          <p class="text-gray-400 text-xs">${headerData.footerCopyright}</p>
+        </div>
+      </footer>
+    `;
+
+    const accordionJs = `
+      <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const smoothScrollTo = (elementY, duration = 1000) => {
+                const startingY = window.pageYOffset;
+                const diff = elementY - startingY;
+                let start;
+
+                const step = (timestamp) => {
+                    if (!start) start = timestamp;
+                    const time = timestamp - start;
+                    const percent = Math.min(time / duration, 1);
+                    const easing = percent < 0.5 ? 4 * percent * percent * percent : 1 - Math.pow(-2 * percent + 2, 3) / 2;
+                    window.scrollTo(0, startingY + diff * easing);
+                    if (time < duration) {
+                        window.requestAnimationFrame(step);
+                    }
+                }
+                window.requestAnimationFrame(step);
+            }
+
+            document.querySelectorAll('.section-header').forEach(header => {
+                header.addEventListener('click', function() {
+                    const content = this.nextElementSibling;
+                    const icon = this.querySelector('.toggle-icon');
+
+                    if (content && icon) {
+                        const isClosed = content.classList.contains('closed');
+
+                        if (isClosed) {
+                            content.classList.remove('closed');
+                            icon.classList.add('rotated');
+                        } else {
+                            content.classList.add('closed');
+                            icon.classList.remove('rotated');
+                        }
+                    }
+                });
+            });
+
+            document.querySelectorAll('nav a').forEach(link => {
+                link.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    const targetId = this.getAttribute('href').substring(1);
+                    const targetSection = document.getElementById(targetId);
+
+                    if (targetSection) {
+                        const content = targetSection.querySelector('.content-container');
+                        const icon = targetSection.querySelector('.toggle-icon');
+
+                        if (content && content.classList.contains('closed')) {
+                            content.classList.remove('closed');
+                            if (icon) icon.classList.add('rotated');
+                        }
+
+                        const elementPosition = targetSection.getBoundingClientRect().top + window.pageYOffset;
+                        const offsetPosition = elementPosition - 60;
+                        smoothScrollTo(offsetPosition, 1000);
+                    }
+                });
+            });
+        });
+      </script>`;
+
+    const fixedStyles = `
+      <style>
+        .logo {
+            max-height: 80px;
+            margin-bottom: 15px;
+            display: block;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .toggle-icon {
+            transition: transform 0.3s ease-in-out;
+        }
+        .toggle-icon.rotated {
+            transform: rotate(90deg);
+        }
+        body {
+            background-color: #f9fafb;
+        }
+        .content-container {
+            display: grid;
+            grid-template-rows: 1fr;
+            transition: grid-template-rows 0.7s cubic-bezier(0.83, 0, 0.17, 1), opacity 0.5s ease-out;
+            opacity: 1;
+            overflow: hidden;
+        }
+        .content-container.closed {
+            grid-template-rows: 0fr;
+            opacity: 0;
+        }
+        .content-container > div {
+            min-height: 0;
+            overflow: hidden;
+        }
+        .content-container * {
+            will-change: auto;
+        }
+      </style>`;
+
+    const fullHtml = `
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Week ${week} - ${headerData.courseTopic}</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+        ${fixedStyles}
+      </head>
+      <body class="bg-gray-50">
+        ${headerHtml}
+        ${navHtml}
+        <div class="max-w-md mx-auto px-4 py-6">
+            ${sectionsHtml}
+        </div>
+        ${footerHtml}
+        ${accordionJs}
+      </body>
+      </html>
+    `;
+
+    const blob = new Blob([fullHtml], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `Week${week}_Lecture_${date.replace(/[^a-zA-Z0-9]/g, '_')}_Mobile.html`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    showSaveIndicator('🔒 Mobile HTML exported');
+  };
+
   const handleSave = () => {
     const sectionsObject = sections.reduce((obj, section) => {
       obj[section.id] = section.blocks.map(({ id, ...rest }) => rest);
@@ -3783,6 +3999,7 @@ const LectureTemplateSystem = ({ initialData }) => {
         onToggleEditMode={handleToggleEditMode}
         onExportPDF={handleExportPDF}
         onExportHTML={handleExportHTML}
+        onExportMobileHTML={handleExportMobileHTML}
         onSave={handleSave}
         onLoad={handleLoad}
         onAddSection={handleAddSection}


### PR DESCRIPTION
## Summary
- add "Export Mobile HTML" option in lesson planner controls
- generate locked HTML optimized for mobile devices
- wire new export handler into control panel
- integrate CodeMirror HTML editor with line numbers for HTML blocks

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1270ae99c8330910453bbb3d6190b